### PR TITLE
Create Debian Repository with CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,60 @@
+---
+
+version: 2.1
+
+jobs:
+  build:
+    docker:
+      - image: debian:buster
+    steps:
+      - checkout
+      - run: apt-get update
+      - run: apt-get install -y build-essential devscripts
+      - run: INSTALL_DEPENDENCIES=y ./build.sh
+      - persist_to_workspace:
+          root: build
+          paths:
+            - .
+      - store_artifacts:
+          path: build
+          destination: build
+
+  publish:
+    docker:
+      - image: debian:buster
+    steps:
+      - checkout
+      - add_ssh_keys:
+          fingerprints:
+            - 26:a8:a9:e5:94:f1:79:13:88:2a:c7:74:2f:c3:06:fd
+      - run: apt-get update
+      - run: apt-get install -y aptly gnupg1 gpgv1 ca-certificates git
+      - run: echo $GPG_KEY | base64 -d | gpg1 --import
+      - attach_workspace:
+          at: build
+      - run: ./create-repo.sh
+      - run: mkdir -p ~/.ssh
+      - run: ssh-keyscan github.com > ~/.ssh/known_hosts
+      - run: git config --global user.email "ci@circleci"
+      - run: git config --global user.name "CI"
+      - run: git checkout gh-pages || git checkout -b gh-pages
+      - run: git rm --cached -r .
+      - run: git add pyca .circleci
+      - run: git commit -m "Create Repository"
+      - run: git push --force origin gh-pages
+
+workflows:
+  main:
+    jobs:
+      - build:
+          filters:
+            branches:
+              ignore:
+                - gh-pages
+      - publish:
+          requires:
+            - build
+          filters:
+            branches:
+              only:
+                - master

--- a/Readme.md
+++ b/Readme.md
@@ -8,3 +8,8 @@ To create the package run the `build.sh` from within this directory.
 If you also want to install the build dependencies, you can run `INSTALL_DEPENDENCIES=y ./build.sh`, but you then need root privileges.
 
 If you would like to look in the process in more details, take a look into the script or visit the [Debian New Maintainers' Guide](https://www.debian.org/doc/manuals/maint-guide/) as a complete source about packaging for Debian.
+
+## Create a repository
+
+There is also a small script in this repository to create a Debian Repository using [aptly](https://www.aptly.info/).
+It is mostly intented to be used with the CI, but if you want to use it manually, you will need to habe a GPG key to sign the repository with.

--- a/build.sh
+++ b/build.sh
@@ -29,4 +29,7 @@ cp -r debian ../pyca/
     debuild -tc -us -uc
 )
 
-printf "\nSuccess. You find your brand new packages under '..'\n"
+mkdir -p build
+cp ../*.deb ../*.buildinfo ../*.changes ../*.debian.tar.xz ../*.dsc ../*.orig.tar.gz build
+
+printf "\nSuccess. You find your brand new packages under 'build'\n"

--- a/create-repo.sh
+++ b/create-repo.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+set -e
+set -u
+
+REPO_NAME=pyca
+
+TMP=$(mktemp -d aptly-XXXXX)
+function finish {
+  rm -rf "$TMP"
+}
+trap finish EXIT
+
+echo "{\"rootDir\": \"$TMP/.aptly\"}" > "$TMP/.aptly.conf"
+aptly "-config=$TMP/.aptly.conf" repo create "$REPO_NAME"
+aptly "-config=$TMP/.aptly.conf" repo add "$REPO_NAME" build/*{.deb,dsc}
+aptly "-config=$TMP/.aptly.conf" publish repo -distribution=Debian "$REPO_NAME" "$REPO_NAME"
+cp -r "$TMP/.aptly/public/$REPO_NAME" .


### PR DESCRIPTION
This patch introduces the config files and scripts needed to create a Debian
Repository from the packaing and deploy is as github pages.