### PR TITLE
Upstream Release 3.2

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+opencast-pyca (3.2-1) unstable; urgency=medium
+
+  * New upstream release
+
+ -- Lars Kiesow <lkiesow@uos.de>  Sat, 18 Jul 2020 00:26:53 +0200
+
 opencast-pyca (3.1-1) unstable; urgency=medium
 
   * New upstream release

--- a/debian/control
+++ b/debian/control
@@ -2,6 +2,7 @@ Source: opencast-pyca
 Section: misc
 Priority: optional
 Maintainer: Sven Haardiek <sven@haardiek.de>
+Uploaders: Lars Kiesow <lkiesow@uos.de>
 Build-Depends: debhelper (>=11~), dh-python, python3-all, python3-setuptools, debhelper-compat (= 12), dh-sequence-python3, npm
 Standards-Version: 4.3.0
 Homepage: https://github.com/opencast/pyCA


### PR DESCRIPTION
This patch updates the packaging to the new 3.2 upstream release of
pyCA.