### PR TITLE
Do not start and enable services per default

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+opencast-pyca (3.2-2) unstable; urgency=medium
+
+  * Do not start services per default #6
+
+ -- Sven Haardiek <sven@haardiek.de>  Thu, 23 Jul 2020 11:30:39 +0200
+
 opencast-pyca (3.2-1) unstable; urgency=medium
 
   * New upstream release

--- a/debian/rules
+++ b/debian/rules
@@ -16,3 +16,6 @@ override_dh_auto_build:
 	npm ci --no-cache
 	npm run build
 	dh_auto_build --buildsystem=pybuild
+
+override_dh_installsystemd:
+	dh_installsystemd -O--buildsystem=pybuild --no-enable --no-start


### PR DESCRIPTION
This patch overrides the default behavior of dh_installsystemd to
not start or enable the services per default.

Closes #6